### PR TITLE
Fix default locale fallback

### DIFF
--- a/src/Back/Helper/Web.js
+++ b/src/Back/Helper/Web.js
@@ -48,7 +48,7 @@ export default class Fl32_Cms_Back_Helper_Web {
                 const short = lang.split('-')[0];
                 if (allowed.includes(short)) return short;
             }
-            return config.getLocaleBaseWeb;
+            return config.getLocaleBaseWeb();
         }
 
         /**


### PR DESCRIPTION
## Summary
- fix missing method invocation in `Fl32_Cms_Back_Helper_Web`

## Testing
- `npm run eslint` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848f4ab4c98832daa7bb84077e4c819