### PR TITLE
Fix Node version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pages are rendered on request using locale-specific templates from the server fi
 
 ## Requirements
 
-- Node.js >= 22
+- Node.js >= 20
 - Tequila Framework (`teqfw`)
 - Plugins: `@flancer32/teq-web`, `@flancer32/teq-tmpl`
 


### PR DESCRIPTION
## Summary
- specify Node.js >=20 in README to match package.json

## Testing
- `npm run eslint` *(fails: `./node_modules/.bin/eslint: not found`)*
- `npm run test:unit` *(fails: `./node_modules/.bin/_mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848fc7d9af4832da1e5f5e6b3a08a5f