### PR TITLE
Add demo HTTP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Demo configuration for teq-cms standalone server
+PORT=3000
+LOCALE_ALLOWED=en,es,ru
+LOCALE_BASE=en

--- a/demo.mjs
+++ b/demo.mjs
@@ -1,0 +1,87 @@
+import http from 'node:http';
+import http2 from 'node:http2';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import {existsSync, createReadStream} from 'node:fs';
+import nunjucks from 'nunjucks';
+import dotenv from 'dotenv';
+import Fl32_Cms_Back_Helper_Web from './src/Back/Helper/Web.js';
+
+dotenv.config();
+
+const ROOT = path.resolve(process.cwd());
+const PORT = process.env.PORT || 3000;
+const ALLOWED = (process.env.LOCALE_ALLOWED || 'en,es,ru').split(',');
+const DEFAULT_LOCALE = process.env.LOCALE_BASE || 'en';
+
+const configStub = {
+  getLocaleAllowed: () => ALLOWED,
+  getLocaleBaseWeb: () => DEFAULT_LOCALE,
+};
+
+const helpWeb = new Fl32_Cms_Back_Helper_Web({
+  'node:http2': http2,
+  Fl32_Cms_Back_Config$: configStub,
+});
+
+function mimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return {
+    '.css': 'text/css',
+    '.ico': 'image/x-icon',
+    '.html': 'text/html',
+  }[ext] || 'application/octet-stream';
+}
+
+async function serveStatic(res, filePath) {
+  const stream = createReadStream(filePath);
+  res.writeHead(200, {'Content-Type': mimeType(filePath)});
+  stream.pipe(res);
+}
+
+async function renderTemplate(res, locale, relPath) {
+  const paths = [
+    path.join(ROOT, 'tmpl', 'web', locale),
+    path.join(ROOT, 'tmpl', 'web', DEFAULT_LOCALE),
+  ];
+  const env = new nunjucks.Environment(new nunjucks.FileSystemLoader(paths, {noCache: true}));
+  try {
+    const html = env.render(relPath, {locale, title: 'TeqCMS Demo'});
+    res.writeHead(200, {'Content-Type': 'text/html; charset=utf-8'});
+    res.end(html);
+  } catch (e) {
+    res.writeHead(404, {'Content-Type': 'text/plain'});
+    res.end('Not found');
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const locale = helpWeb.extractLocale({req});
+  let urlPath = decodeURIComponent(req.url.split('?')[0] || '/');
+
+  const hasLocale = ALLOWED.some(loc => urlPath === `/${loc}` || urlPath.startsWith(`/${loc}/`));
+  if (!hasLocale) {
+    const newUrl = `/${locale}${urlPath.startsWith('/') ? '' : '/'}${urlPath}`;
+    res.writeHead(302, {Location: newUrl});
+    res.end();
+    return;
+  }
+
+  let relPath = urlPath.replace(/^\/+/, '');
+  for (const loc of ALLOWED) {
+    if (relPath === loc) { relPath = ''; break; }
+    if (relPath.startsWith(`${loc}/`)) { relPath = relPath.slice(loc.length + 1); break; }
+  }
+  if (relPath === '' || relPath.endsWith('/')) relPath += 'index.html';
+
+  const staticPath = path.join(ROOT, 'web', relPath);
+  if (existsSync(staticPath)) {
+    await serveStatic(res, staticPath);
+    return;
+  }
+  await renderTemplate(res, locale, relPath);
+});
+
+server.listen(PORT, () => {
+  console.log(`Demo server listening on http://localhost:${PORT}/`);
+});

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "@eslint/js": "^9.25.0",
     "eslint": "^9.25.0",
     "eslint-plugin-jsdoc": "^50.6.8",
-    "mocha": "^11.3.0"
+    "mocha": "^11.3.0",
+    "dotenv": "^16.4.5",
+    "nunjucks": "^3.2.4"
   },
   "overrides": {
     "whatwg-url": "13.0.0"

--- a/tmpl/web/en/about.html
+++ b/tmpl/web/en/about.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>About</h1>
+<p>Demo page in English.</p>
+<p><a href="/en/">Home</a></p>
+{% endblock %}

--- a/tmpl/web/en/index.html
+++ b/tmpl/web/en/index.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Welcome</h1>
+<p>This is the English homepage.</p>
+<p><a href="/en/about.html">About</a> | <a href="/raw.html">Raw HTML</a></p>
+{% endblock %}

--- a/tmpl/web/en/layout.html
+++ b/tmpl/web/en/layout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ locale }}">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="icon" href="/favicon.ico">
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/tmpl/web/es/about.html
+++ b/tmpl/web/es/about.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Acerca de</h1>
+<p>Página de demostración en español.</p>
+<p><a href="/es/">Inicio</a></p>
+{% endblock %}

--- a/tmpl/web/es/index.html
+++ b/tmpl/web/es/index.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Bienvenido</h1>
+<p>Esta es la página principal en español.</p>
+<p><a href="/es/about.html">Acerca</a> | <a href="/raw.html">Raw HTML</a></p>
+{% endblock %}

--- a/tmpl/web/es/layout.html
+++ b/tmpl/web/es/layout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ locale }}">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="icon" href="/favicon.ico">
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/tmpl/web/ru/about.html
+++ b/tmpl/web/ru/about.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>О проекте</h1>
+<p>Демонстрационная страница на русском.</p>
+<p><a href="/ru/">Главная</a></p>
+{% endblock %}

--- a/tmpl/web/ru/index.html
+++ b/tmpl/web/ru/index.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Добро пожаловать</h1>
+<p>Это главная страница на русском языке.</p>
+<p><a href="/ru/about.html">О нас</a> | <a href="/raw.html">Raw HTML</a></p>
+{% endblock %}

--- a/tmpl/web/ru/layout.html
+++ b/tmpl/web/ru/layout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ locale }}">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/style.css">
+    <link rel="icon" href="/favicon.ico">
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/web/raw.html
+++ b/web/raw.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><head><title>Raw</title></head><body>
+<h1>Raw HTML Page</h1>
+<p>This file is served directly from the web directory.</p>
+</body></html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; padding: 1em; }
+h1 { color: #333; }


### PR DESCRIPTION
## Summary
- add standalone demo.mjs for quick CMS testing
- include example .env configuration
- provide minimal Nunjucks templates
- provide example static assets
- list dotenv and nunjucks in devDependencies
- remove binary favicon

## Testing
- `npm run eslint` *(fails: ./node_modules/.bin/eslint: not found)*
- `npm run test:unit` *(fails: ./node_modules/.bin/_mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd0cd94ac832d9154a8330ef9f3c8