### PR TITLE
Enable locale switch links on demo about pages

### DIFF
--- a/tmpl/web/en/about.html
+++ b/tmpl/web/en/about.html
@@ -17,7 +17,7 @@
 <main>
   <h1>About</h1>
   <p>This is a demo page rendered by TeqCMS.</p>
-  <p>Available locales: {{ lang1 }}, {{ lang2 }}, {{ lang3 }}</p>
+  <p>Available locales: <a href="/{{ lang1 }}/about.html">{{ lang1 }}</a>, <a href="/{{ lang2 }}/about.html">{{ lang2 }}</a>, <a href="/{{ lang3 }}/about.html">{{ lang3 }}</a></p>
 </main>
 </body>
 </html>

--- a/tmpl/web/es/about.html
+++ b/tmpl/web/es/about.html
@@ -17,7 +17,7 @@
 <main>
   <h1>Acerca de</h1>
   <p>Página de demostración de TeqCMS.</p>
-  <p>Idiomas disponibles: {{ lang1 }}, {{ lang2 }}, {{ lang3 }}</p>
+  <p>Idiomas disponibles: <a href="/{{ lang1 }}/about.html">{{ lang1 }}</a>, <a href="/{{ lang2 }}/about.html">{{ lang2 }}</a>, <a href="/{{ lang3 }}/about.html">{{ lang3 }}</a></p>
 </main>
 </body>
 </html>

--- a/tmpl/web/ru/about.html
+++ b/tmpl/web/ru/about.html
@@ -17,7 +17,7 @@
 <main>
   <h1>О проекте</h1>
   <p>Демонстрационная страница TeqCMS.</p>
-  <p>Доступные языки: {{ lang1 }}, {{ lang2 }}, {{ lang3 }}</p>
+  <p>Доступные языки: <a href="/{{ lang1 }}/about.html">{{ lang1 }}</a>, <a href="/{{ lang2 }}/about.html">{{ lang2 }}</a>, <a href="/{{ lang3 }}/about.html">{{ lang3 }}</a></p>
 </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- linkify available locale list on about pages so users can switch between languages

## Testing
- `npm run test:unit` *(fails: `./node_modules/.bin/_mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e76d0f9cc832dbd7727fa2c07abe4