### PR TITLE
Add web CLI command

### DIFF
--- a/bin/teq-cms.js
+++ b/bin/teq-cms.js
@@ -5,6 +5,7 @@ import {dirname, join} from 'node:path';
 import {existsSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import Container from '@teqfw/di';
+import Replace from '@teqfw/di/src/Pre/Replace.js';
 
 // VARS
 /* Resolve a path to the root folder. */
@@ -35,6 +36,12 @@ if (root) {
     // set up the namespaces for the deps
     resolver.addNamespaceRoot('Fl32_Cms_', join(node, '@flancer32', 'teq-cms', 'src'));
     resolver.addNamespaceRoot('Fl32_Tmpl_', join(node, '@flancer32', 'teq-tmpl', 'src'));
+    resolver.addNamespaceRoot('Fl32_Web_', join(node, '@flancer32', 'teq-web', 'src'));
+
+    const replace = new Replace();
+    replace.add('Fl32_Cms_Back_Api_Adapter', 'Fl32_Cms_Back_Di_Adapter');
+    replace.add('Fl32_Tmpl_Back_Api_Adapter', 'Fl32_Tmpl_Back_Di_Adapter');
+    container.getPreProcessor().addChunk(replace);
     /** @type {Fl32_Cms_Back_Cli_Command} */
     const command = await container.get('Fl32_Cms_Back_Cli_Command$');
     await command.run(rootCms, process.argv);

--- a/src/Back/Cli/Command.js
+++ b/src/Back/Cli/Command.js
@@ -8,6 +8,7 @@ export default class Fl32_Cms_Back_Cli_Command {
      * @param {Fl32_Cms_Back_Config} config
      * @param {Fl32_Cms_Back_Gate_OpenAI} gateOpenAI
      * @param {Fl32_Cms_Back_Cli_Command_Translate} cmdTranslate
+     * @param {Fl32_Cms_Back_Cli_Command_Web} cmdWeb
      */
     constructor(
         {
@@ -15,6 +16,7 @@ export default class Fl32_Cms_Back_Cli_Command {
             Fl32_Cms_Back_Config$: config,
             Fl32_Cms_Back_Gate_OpenAI$: gateOpenAI,
             Fl32_Cms_Back_Cli_Command_Translate$: cmdTranslate,
+            Fl32_Cms_Back_Cli_Command_Web$: cmdWeb,
         }
     ) {
         /* eslint-enable jsdoc/require-param-description,jsdoc/check-param-names */
@@ -40,6 +42,9 @@ export default class Fl32_Cms_Back_Cli_Command {
                 case CMD.TRANSLATE:
                     await cmdTranslate.exec();
                     break;
+                case CMD.WEB:
+                    await cmdWeb.exec();
+                    break;
                 default:
                     console.log('Unknown command:', cmd);
                     process.exit(1);
@@ -52,4 +57,5 @@ export default class Fl32_Cms_Back_Cli_Command {
 
 const CMD = {
     TRANSLATE: 'translate',
+    WEB: 'web',
 };

--- a/src/Back/Cli/Command/Web.js
+++ b/src/Back/Cli/Command/Web.js
@@ -1,0 +1,44 @@
+/**
+ * Launch the demo web server using configured environment settings.
+ */
+export default class Fl32_Cms_Back_Cli_Command_Web {
+    /* eslint-disable jsdoc/require-param-description,jsdoc/check-param-names */
+    /**
+     * @param {typeof import('node:path')} path
+     * @param {Fl32_Cms_Back_Config} config
+     * @param {Fl32_Web_Back_Dispatcher} dispatcher
+     * @param {Fl32_Web_Back_Handler_Pre_Log} handLog
+     * @param {Fl32_Web_Back_Handler_Static} handStatic
+     * @param {Fl32_Cms_Back_Web_Handler_Template} handTmpl
+     * @param {Fl32_Web_Back_Server_Config} dtoConfigWeb
+     * @param {Fl32_Web_Back_Server} server
+     */
+    constructor({
+        'node:path': path,
+        Fl32_Cms_Back_Config$: config,
+        Fl32_Web_Back_Dispatcher$: dispatcher,
+        Fl32_Web_Back_Handler_Pre_Log$: handLog,
+        Fl32_Web_Back_Handler_Static$: handStatic,
+        Fl32_Cms_Back_Web_Handler_Template$: handTmpl,
+        Fl32_Web_Back_Server_Config$: dtoConfigWeb,
+        Fl32_Web_Back_Server$: server,
+    }) {
+        /* eslint-enable jsdoc/require-param-description,jsdoc/check-param-names */
+        this.exec = async function () {
+            const rootCms = config.getRootPath();
+            const rootWeb = path.join(rootCms, 'web');
+
+            await handStatic.init({rootPath: rootWeb});
+
+            dispatcher.addHandler(handLog);
+            dispatcher.addHandler(handStatic);
+            dispatcher.addHandler(handTmpl);
+
+            const cfg = dtoConfigWeb.create({
+                port: process.env.PORT,
+                type: 'http',
+            });
+            await server.start(cfg);
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `web` command wiring into CLI entry
- configure DI container with adapter replacements
- implement `Fl32_Cms_Back_Cli_Command_Web` using DI

## Testing
- `npm run eslint` *(fails: `./node_modules/.bin/eslint: not found`)*
- `npm run test:unit` *(fails: `./node_modules/.bin/_mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fd2f415fc832d9ccf58443c4e8fda