### PR TITLE
Centralize web server configuration

### DIFF
--- a/src/Back/Cli/Command/Web.js
+++ b/src/Back/Cli/Command/Web.js
@@ -10,7 +10,6 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
      * @param {Fl32_Web_Back_Handler_Pre_Log} handLog
      * @param {Fl32_Web_Back_Handler_Static} handStatic
      * @param {Fl32_Cms_Back_Web_Handler_Template} handTmpl
-     * @param {Fl32_Web_Back_Server_Config} dtoConfigWeb
      * @param {Fl32_Web_Back_Server} server
      */
     constructor({
@@ -20,7 +19,6 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
         Fl32_Web_Back_Handler_Pre_Log$: handLog,
         Fl32_Web_Back_Handler_Static$: handStatic,
         Fl32_Cms_Back_Web_Handler_Template$: handTmpl,
-        Fl32_Web_Back_Server_Config$: dtoConfigWeb,
         Fl32_Web_Back_Server$: server,
     }) {
         /* eslint-enable jsdoc/require-param-description,jsdoc/check-param-names */
@@ -34,10 +32,7 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
             dispatcher.addHandler(handStatic);
             dispatcher.addHandler(handTmpl);
 
-            const cfg = dtoConfigWeb.create({
-                port: process.env.PORT,
-                type: 'http',
-            });
+            const cfg = config.getWebServerConfigDto();
             await server.start(cfg);
         };
     }

--- a/src/Back/Config.js
+++ b/src/Back/Config.js
@@ -8,11 +8,13 @@ export default class Fl32_Cms_Back_Config {
     /**
      * @param {Fl32_Cms_Back_Helper_Cast} cast - Type casting helper
      * @param {Fl32_Tmpl_Back_Config} configTmpl - Template engine configuration
+     * @param {Fl32_Web_Back_Server_Config} serverConfigFactory
      */
     constructor(
         {
             Fl32_Cms_Back_Helper_Cast$: cast,
             Fl32_Tmpl_Back_Config$: configTmpl,
+            Fl32_Web_Back_Server_Config$: serverConfigFactory,
         }
     ) {
         /* eslint-enable jsdoc/check-param-names */
@@ -82,6 +84,12 @@ export default class Fl32_Cms_Back_Config {
          */
         let _rootPath;
 
+        /**
+         * DTO with web server configuration built from environment.
+         * @type {Fl32_Web_Back_Server_Config.Dto}
+         */
+        let _webConfigDto;
+
 
         // MAIN
 
@@ -133,6 +141,18 @@ export default class Fl32_Cms_Back_Config {
                 rootPath: _rootPath,
             });
 
+            const port = cast.int(process.env.TEQ_CMS_SERVER_PORT);
+            const type = cast.string(process.env.TEQ_CMS_SERVER_TYPE);
+            const cert = cast.string(process.env.TEQ_CMS_TLS_CERT);
+            const key = cast.string(process.env.TEQ_CMS_TLS_KEY);
+            const ca = cast.string(process.env.TEQ_CMS_TLS_CA);
+
+            _webConfigDto = serverConfigFactory.create({
+                port,
+                type,
+                tls: cert && key ? {cert, key, ca} : undefined,
+            });
+
             _isInit = true;
         };
 
@@ -178,5 +198,10 @@ export default class Fl32_Cms_Back_Config {
          * @returns {string} Absolute application root path
          */
         this.getRootPath = () => _rootPath;
+
+        /**
+         * @returns {Fl32_Web_Back_Server_Config.Dto}
+         */
+        this.getWebServerConfigDto = () => _webConfigDto;
     }
 }


### PR DESCRIPTION
## Summary
- get validated web server configuration from the CMS config
- build server config DTO on init using environment variables

## Testing
- `npm run eslint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685101e21658832d93586411d13e30e7