### PR TITLE
Remove env usage from config, update env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Demo configuration for teq-cms standalone server
-LOCALE_ALLOWED=en,es,ru
-LOCALE_BASE=en
-PORT=3000
-TEQ_CMS_ROOT=
-TEQ_CMS_TMPL_ENGINE=[nunjucks|simple|mustache]
+TEQ_CMS_AI_API_BASE_URL=https://api.openai.com/v1
+TEQ_CMS_AI_API_KEY=sk-xxx
+TEQ_CMS_AI_API_MODEL=gpt-3.5-turbo
+TEQ_CMS_AI_API_ORG=org-xxx
+TEQ_CMS_LOCALE_ALLOWED=en,es,ru
+TEQ_CMS_LOCALE_BASE_TRANSLATE=ru
+TEQ_CMS_LOCALE_BASE_DISPLAY=en
+TEQ_CMS_TMPL_ENGINE=nunjucks
+TEQ_CMS_SERVER_PORT=3000
+TEQ_CMS_SERVER_TYPE=http
+TEQ_CMS_TLS_CERT=/path/to/cert.pem
+TEQ_CMS_TLS_KEY=/path/to/key.pem
+TEQ_CMS_TLS_CA=/path/to/ca.pem

--- a/src/Back/Cli/Command.js
+++ b/src/Back/Cli/Command.js
@@ -31,6 +31,11 @@ export default class Fl32_Cms_Back_Cli_Command {
                 localeBaseWeb: process.env.TEQ_CMS_LOCALE_BASE_DISPLAY || 'en',
                 rootPath: root,
                 tmplEngine: process.env.TEQ_CMS_TMPL_ENGINE,
+                serverPort: process.env.TEQ_CMS_SERVER_PORT || 3000,
+                serverType: process.env.TEQ_CMS_SERVER_TYPE || 'http',
+                tlsCert: process.env.TEQ_CMS_TLS_CERT,
+                tlsKey: process.env.TEQ_CMS_TLS_KEY,
+                tlsCa: process.env.TEQ_CMS_TLS_CA,
             });
 
             const cmd = argv[2];

--- a/src/Back/Config.js
+++ b/src/Back/Config.js
@@ -85,7 +85,7 @@ export default class Fl32_Cms_Back_Config {
         let _rootPath;
 
         /**
-         * DTO with web server configuration built from environment.
+         * DTO with web server configuration built from provided parameters.
          * @type {Fl32_Web_Back_Server_Config.Dto}
          */
         let _webConfigDto;
@@ -106,6 +106,11 @@ export default class Fl32_Cms_Back_Config {
          * @param {string} args.localeBaseWeb - Default locale for rendering
          * @param {string} args.rootPath - Application root directory
          * @param {string} args.tmplEngine - Template engine name
+         * @param {number} args.serverPort - Web server port
+         * @param {string} args.serverType - Type of the web server
+         * @param {string} args.tlsCert - Path to TLS certificate
+         * @param {string} args.tlsKey - Path to TLS private key
+         * @param {string} [args.tlsCa] - Optional path to TLS CA certificate
          * @throws {Error} If initialized more than once
          */
         this.init = function (args) {
@@ -123,6 +128,11 @@ export default class Fl32_Cms_Back_Config {
                 localeBaseWeb,
                 rootPath,
                 tmplEngine,
+                serverPort,
+                serverType,
+                tlsCert,
+                tlsKey,
+                tlsCa,
             } = args;
 
             _aiApiBaseUrl = cast.string(aiApiBaseUrl);
@@ -141,11 +151,11 @@ export default class Fl32_Cms_Back_Config {
                 rootPath: _rootPath,
             });
 
-            const port = cast.int(process.env.TEQ_CMS_SERVER_PORT);
-            const type = cast.string(process.env.TEQ_CMS_SERVER_TYPE);
-            const cert = cast.string(process.env.TEQ_CMS_TLS_CERT);
-            const key = cast.string(process.env.TEQ_CMS_TLS_KEY);
-            const ca = cast.string(process.env.TEQ_CMS_TLS_CA);
+            const port = cast.int(serverPort);
+            const type = cast.string(serverType);
+            const cert = cast.string(tlsCert);
+            const key = cast.string(tlsKey);
+            const ca = cast.string(tlsCa);
 
             _webConfigDto = serverConfigFactory.create({
                 port,


### PR DESCRIPTION
## Summary
- pass server config to `init` instead of reading env in the config
- expand CLI initialization arguments accordingly
- document only CLI env variables in `.env.example`
- add sample values to `.env.example` and set defaults in CLI

## Testing
- `npm test` *(fails: Cannot find package '@teqfw/di')*
- `npm run eslint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510720a4e4832dbae95eb031f6ee3f