### PR TITLE
Fix template resolution to ignore directories

### DIFF
--- a/src/Back/Helper/File.js
+++ b/src/Back/Helper/File.js
@@ -92,20 +92,26 @@ export default class Fl32_Cms_Back_Helper_File {
             const trimmed = (cleanPath ?? '').replace(/^\/+|\/+$/g, '');
 
             try {
-                await access(join(baseDir, trimmed), constants.R_OK);
-                return trimmed;
+                const fullPath = join(baseDir, trimmed);
+                await access(fullPath, constants.R_OK);
+                const statRes = await stat(fullPath);
+                if (statRes.isFile()) return trimmed;
             } catch {}
 
             const indexVariant = join(trimmed, 'index.html');
             try {
-                await access(join(baseDir, indexVariant), constants.R_OK);
-                return indexVariant;
+                const fullPath = join(baseDir, indexVariant);
+                await access(fullPath, constants.R_OK);
+                const statRes = await stat(fullPath);
+                if (statRes.isFile()) return indexVariant;
             } catch {}
 
             const htmlVariant = trimmed ? `${trimmed}.html` : 'index.html';
             try {
-                await access(join(baseDir, htmlVariant), constants.R_OK);
-                return htmlVariant;
+                const fullPath = join(baseDir, htmlVariant);
+                await access(fullPath, constants.R_OK);
+                const statRes = await stat(fullPath);
+                if (statRes.isFile()) return htmlVariant;
             } catch {}
 
             return undefined;

--- a/test/unit/Back/Di/Replace/Adapter.test.mjs
+++ b/test/unit/Back/Di/Replace/Adapter.test.mjs
@@ -8,6 +8,8 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
 
     /** @type {string[]} */
     let accessiblePaths = [];
+    /** @type {Record<string, boolean>} */
+    let fileStatuses = {};
 
     // Register mocks
     container.register('node:fs', {
@@ -16,6 +18,10 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
                 if (!accessiblePaths.includes(p)) {
                     throw new Error('ENOENT');
                 }
+            },
+            stat: async (p) => {
+                if (p in fileStatuses) return {isFile: () => fileStatuses[p]};
+                throw new Error('ENOENT');
             },
         },
         constants: {
@@ -41,6 +47,7 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
     it('should resolve index.html in folder path', async () => {
         const Adapter = await container.get('Fl32_Cms_Back_Di_Replace_Adapter$');
         accessiblePaths = ['/abs/app/root/tmpl/web/en/path/to/index.html'];
+        fileStatuses = {'/abs/app/root/tmpl/web/en/path/to/index.html': true};
 
         const result = await Adapter.getRenderData({
             req: {url: '/ru/path/to/', headers: {}, socket: {}},
@@ -52,6 +59,7 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
     it('should resolve clean .html file', async () => {
         const Adapter = await container.get('Fl32_Cms_Back_Di_Replace_Adapter$');
         accessiblePaths = ['/abs/app/root/tmpl/web/en/about.html'];
+        fileStatuses = {'/abs/app/root/tmpl/web/en/about.html': true};
 
         const result = await Adapter.getRenderData({
             req: {url: '/ru/about.html', headers: {}, socket: {}},
@@ -63,6 +71,7 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
     it('should pass through non-html file', async () => {
         const Adapter = await container.get('Fl32_Cms_Back_Di_Replace_Adapter$');
         accessiblePaths = ['/abs/app/root/tmpl/web/en/style.css'];
+        fileStatuses = {'/abs/app/root/tmpl/web/en/style.css': true};
 
         const result = await Adapter.getRenderData({
             req: {url: '/style.css', headers: {}, socket: {}},
@@ -74,6 +83,7 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
     it('should return undefined for missing template', async () => {
         const Adapter = await container.get('Fl32_Cms_Back_Di_Replace_Adapter$');
         accessiblePaths = [];
+        fileStatuses = {};
 
         const result = await Adapter.getRenderData({
             req: {url: '/ru/missing/page', headers: {}, socket: {}},

--- a/test/unit/Back/Helper/File.test.mjs
+++ b/test/unit/Back/Helper/File.test.mjs
@@ -7,6 +7,8 @@ describe('Fl32_Cms_Back_Helper_File.resolveTemplateName', () => {
     const container = buildTestContainer();
     /** @type {string[]} */
     let accessible = [];
+    /** @type {Record<string, boolean>} */
+    let files = {};
 
     container.register('node:fs', {
         promises: {
@@ -14,6 +16,10 @@ describe('Fl32_Cms_Back_Helper_File.resolveTemplateName', () => {
                 if (!accessible.includes(p)) {
                     throw new Error('ENOENT');
                 }
+            },
+            stat: async (p) => {
+                if (p in files) return {isFile: () => files[p]};
+                throw new Error('ENOENT');
             },
         },
         constants: {R_OK: 4},
@@ -31,6 +37,7 @@ describe('Fl32_Cms_Back_Helper_File.resolveTemplateName', () => {
     it('should return exact file when exists', async () => {
         const helper = await container.get('Fl32_Cms_Back_Helper_File$');
         accessible = ['/root/base/foo.txt'];
+        files = {'/root/base/foo.txt': true};
         const res = await helper.resolveTemplateName({baseDir: '/root/base', cleanPath: 'foo.txt'});
         assert.strictEqual(res, 'foo.txt');
     });
@@ -38,6 +45,7 @@ describe('Fl32_Cms_Back_Helper_File.resolveTemplateName', () => {
     it('should resolve index.html in folder', async () => {
         const helper = await container.get('Fl32_Cms_Back_Helper_File$');
         accessible = ['/root/base/bar/index.html'];
+        files = {'/root/base/bar/index.html': true};
         const res = await helper.resolveTemplateName({baseDir: '/root/base', cleanPath: 'bar'});
         assert.strictEqual(res, 'bar/index.html');
     });
@@ -45,13 +53,23 @@ describe('Fl32_Cms_Back_Helper_File.resolveTemplateName', () => {
     it('should append .html when exists', async () => {
         const helper = await container.get('Fl32_Cms_Back_Helper_File$');
         accessible = ['/root/base/about.html'];
+        files = {'/root/base/about.html': true};
         const res = await helper.resolveTemplateName({baseDir: '/root/base', cleanPath: 'about'});
         assert.strictEqual(res, 'about.html');
+    });
+
+    it('should not resolve when path is directory', async () => {
+        const helper = await container.get('Fl32_Cms_Back_Helper_File$');
+        accessible = ['/root/base/dir'];
+        files = {'/root/base/dir': false};
+        const res = await helper.resolveTemplateName({baseDir: '/root/base', cleanPath: 'dir'});
+        assert.strictEqual(res, undefined);
     });
 
     it('should return undefined when not found', async () => {
         const helper = await container.get('Fl32_Cms_Back_Helper_File$');
         accessible = [];
+        files = {};
         const res = await helper.resolveTemplateName({baseDir: '/root/base', cleanPath: 'miss'});
         assert.strictEqual(res, undefined);
     });


### PR DESCRIPTION
## Summary
- ensure resolveTemplateName only accepts files
- expand unit tests to mock `fs.stat` and reject directories
- adjust adapter tests for new file checks

## Testing
- `npm test` *(fails: Cannot find package '@teqfw/di')*

------
https://chatgpt.com/codex/tasks/task_e_68514da10280832dbab92a51fd83f220