### PR TITLE
Add canonical links with schemeless URLs

### DIFF
--- a/src/Back/Di/Replace/Adapter.js
+++ b/src/Back/Di/Replace/Adapter.js
@@ -62,14 +62,23 @@ export default class Fl32_Cms_Back_Di_Replace_Adapter {
                         },
                     });
 
+                    const host = req.headers.host;
+                    const baseUrl = `//${host}`;
+
+                    const canonicalUrl = `${baseUrl}/${localeBaseWeb}/${tmplPath}`;
+                    const alternateUrls = {};
+                    for (const loc of localeAllowed) {
+                        alternateUrls[loc] = `${baseUrl}/${loc}/${tmplPath}`;
+                    }
+
                     data = {
                         ip: req.socket?.remoteAddress || '',
                         ua: req.headers['user-agent'] || '',
                         lang: req.headers['accept-language'] || '',
                         locale,
-                        lang1: localeAllowed[0] || '',
-                        lang2: localeAllowed[1] || '',
-                        lang3: localeAllowed[2] || '',
+                        allowedLocales: localeAllowed,
+                        canonicalUrl,
+                        alternateUrls,
                     };
 
                     options = {};

--- a/test/unit/Back/Di/Replace/Adapter.test.mjs
+++ b/test/unit/Back/Di/Replace/Adapter.test.mjs
@@ -50,10 +50,16 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
         fileStatuses = {'/abs/app/root/tmpl/web/en/path/to/index.html': true};
 
         const result = await Adapter.getRenderData({
-            req: {url: '/ru/path/to/', headers: {}, socket: {}},
+            req: {url: '/ru/path/to/', headers: {host: 'site.tst'}, socket: {}},
         });
 
         assert.strictEqual(result.target.name, 'path/to/index.html');
+        assert.strictEqual(result.data.canonicalUrl, '//site.tst/en/path/to/index.html');
+        assert.deepStrictEqual(result.data.alternateUrls, {
+            en: '//site.tst/en/path/to/index.html',
+            ru: '//site.tst/ru/path/to/index.html',
+        });
+        assert.deepStrictEqual(result.data.allowedLocales, ['en', 'ru']);
     });
 
     it('should resolve clean .html file', async () => {
@@ -62,10 +68,27 @@ describe('Fl32_Cms_Back_Di_Replace_Adapter', () => {
         fileStatuses = {'/abs/app/root/tmpl/web/en/about.html': true};
 
         const result = await Adapter.getRenderData({
-            req: {url: '/ru/about.html', headers: {}, socket: {}},
+            req: {url: '/ru/about.html', headers: {host: 'site.tst'}, socket: {}},
         });
 
         assert.strictEqual(result.target.name, 'about.html');
+    });
+
+    it('should use tmplPath for canonical URL on base locale', async () => {
+        const Adapter = await container.get('Fl32_Cms_Back_Di_Replace_Adapter$');
+        accessiblePaths = ['/abs/app/root/tmpl/web/en/about.html'];
+        fileStatuses = {'/abs/app/root/tmpl/web/en/about.html': true};
+
+        const result = await Adapter.getRenderData({
+            req: {url: '/about/', headers: {host: 'site.tst'}, socket: {}},
+        });
+
+        assert.strictEqual(result.target.name, 'about.html');
+        assert.strictEqual(result.data.canonicalUrl, '//site.tst/en/about.html');
+        assert.deepStrictEqual(result.data.alternateUrls, {
+            en: '//site.tst/en/about.html',
+            ru: '//site.tst/ru/about.html',
+        });
     });
 
     it('should pass through non-html file', async () => {


### PR DESCRIPTION
## Summary
- expose canonical and alternate URLs using `//` scheme-less URLs
- delete no-longer-needed `ContainerStub`
- update adapter test expectations and DI setup

## Testing
- `npm test` *(fails: cannot find module '@teqfw/di')*

------
https://chatgpt.com/codex/tasks/task_e_6852537c2cbc832db2cd888e1ba94b16