### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.0] - 2025-06-18
+- Added base URL configuration for generating canonical links.
+- Added canonical and alternate link tags for localized pages.
+
 ## [0.3.0] - 2025-06-18
 - Added canonical and alternate link tags for localized pages using schemeless URLs.
 - Refactored routing logic into helpers and added unit tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flancer32/teq-cms",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@flancer32/teq-tmpl": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Minimalistic file-based CMS for multilingual websites with AI-powered localization and Git-native content workflow.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump version to 0.4.0
- document release notes for v0.4.0

## Testing
- `npm install` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68527b59ca28832d9edb8cd6f4726855