### PR TITLE
Fix web command static handler

### DIFF
--- a/src/Back/Cli/Command/Web.js
+++ b/src/Back/Cli/Command/Web.js
@@ -10,6 +10,7 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
      * @param {Fl32_Web_Back_Handler_Pre_Log} handLog
      * @param {Fl32_Web_Back_Handler_Static} handStatic
      * @param {Fl32_Cms_Back_Web_Handler_Template} handTmpl
+     * @param {Fl32_Web_Back_Dto_Handler_Source} dtoSource
      * @param {Fl32_Web_Back_Server} server
      */
     constructor(
@@ -20,6 +21,7 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
             Fl32_Web_Back_Handler_Pre_Log$: handLog,
             Fl32_Web_Back_Handler_Static$: handStatic,
             Fl32_Cms_Back_Web_Handler_Template$: handTmpl,
+            Fl32_Web_Back_Dto_Handler_Source$: dtoSource,
             Fl32_Web_Back_Server$: server,
         }
     ) {
@@ -28,7 +30,13 @@ export default class Fl32_Cms_Back_Cli_Command_Web {
             const rootCms = config.getRootPath();
             const rootWeb = path.join(rootCms, 'web');
 
-            await handStatic.init({rootPath: rootWeb});
+            const dto = dtoSource.create();
+            dto.root = rootWeb;
+            dto.prefix = '/';
+            dto.allow = {'.': ['.']};
+            dto.defaults = ['index.html'];
+
+            await handStatic.init({sources: [dto]});
 
             dispatcher.addHandler(handLog);
             dispatcher.addHandler(handStatic);

--- a/test/accept/Command/Web.test.mjs
+++ b/test/accept/Command/Web.test.mjs
@@ -1,0 +1,52 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {buildTestContainer} from '../unit/common.js';
+
+async function waitListening(server) {
+  if (!server.getInstance().listening) {
+    await new Promise(res => server.getInstance().once('listening', res));
+  }
+}
+
+describe('Fl32_Cms_Back_Cli_Command_Web', () => {
+  it('should start web server with ./web static root', async () => {
+    const container = buildTestContainer();
+    const cmd = await container.get('Fl32_Cms_Back_Cli_Command_Web$');
+    const server = await container.get('Fl32_Web_Back_Server$');
+    const SERVER_TYPE = await container.get('Fl32_Web_Back_Enum_Server_Type$');
+    const Config = await container.get('Fl32_Cms_Back_Config$');
+    const http = await container.get('node:http');
+
+    Config.init({
+      aiApiBaseUrl: '',
+      aiApiKey: '',
+      aiApiModel: '',
+      aiApiOrg: '',
+      baseUrl: '',
+      localeAllowed: ['en'],
+      localeBaseTranslate: 'en',
+      localeBaseWeb: 'en',
+      rootPath: process.cwd(),
+      tmplEngine: 'simple',
+      serverPort: 3050,
+      serverType: SERVER_TYPE.HTTP,
+      tlsCert: '',
+      tlsKey: '',
+      tlsCa: '',
+    });
+
+    await cmd.exec();
+    await waitListening(server);
+
+    const status = await new Promise((resolve, reject) => {
+      http.get(`http://localhost:3050/raw.html`, res => {
+        const {statusCode} = res;
+        res.resume();
+        res.on('end', () => resolve(statusCode));
+      }).on('error', reject);
+    });
+
+    assert.strictEqual(status, 200);
+    await server.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- configure `Fl32_Cms_Back_Cli_Command_Web` with `Fl32_Web_Back_Dto_Handler_Source`
- add acceptance test for launching the web server

## Testing
- `npm test` *(fails: Cannot find package '@teqfw/di')*

------
https://chatgpt.com/codex/tasks/task_e_685d7dfc2f18832dabde00d382a338e8