### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.5.1] - 2025-06-27
+- Updated acceptance tests for Web CLI command.
+
 ## [0.5.0] - 2025-06-26
 - Added CLI command to run TeqCMS as a web server.
 - Fixed static handler initialization and updated dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flancer32/teq-cms",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@flancer32/teq-tmpl": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Minimalistic file-based CMS for multilingual websites with AI-powered localization and Git-native content workflow.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump version to 0.5.1
- document latest changes in the changelog

## Testing
- `npm test` *(fails: test failed)*
- `npm run eslint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d824eb118832da6578c60dd791905