### PR TITLE
fix: ensure project root traversal when locating node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.3] - 2025-08-13
+
+- Fixed project root detection to traverse parent directories when searching for `node_modules`.
+
 ## [0.5.2] - 2025-07-04
 
 - Implemented auto-continue for long LLM translations.

--- a/bin/teq-cms.js
+++ b/bin/teq-cms.js
@@ -22,7 +22,7 @@ function findProjectRoot() {
     let dir = dirname(fileURLToPath(import.meta.url));
     while (dir !== dirname(dir)) {
         if (existsSync(join(dir, 'node_modules'))) return dir;
-        dir = dirname(dir);
+        dir = dirname(join(dir, '..'));
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flancer32/teq-cms",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@flancer32/teq-tmpl": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flancer32/teq-cms",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Minimalistic file-based CMS for multilingual websites with AI-powered localization and Git-native content workflow.",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- traverse up directories when searching for node_modules
- release version 0.5.3

## Testing
- `npm run test:eslint`
- `npm run test:unit`
- `npm run test:accept`


------
https://chatgpt.com/codex/tasks/task_e_689c8413c138832d89f1be2d2696a52d